### PR TITLE
Feature output limited timestep

### DIFF
--- a/Template-Config.sh
+++ b/Template-Config.sh
@@ -130,7 +130,7 @@ INITIAL_CONDITIONS_CONTAIN_ENTROPY
 #POWERSPEC_ON_OUTPUT                          # computes a matter power spectrum when the code writes a snapshot output
 #ALLOW_HDF5_COMPRESSION                       # applies HDF5 loss-less compression to selected output fields
 #REDUCE_FLUSH                                 # do not flush the I/O streams of the log-files every system step
-
+#OUTPUT_LIMITED_TIMESTEP                      # adapts timesteps to ensure no outputs are skipped due to too large timesteps
 
 #---------------------------------------- On the fly FOF groupfinder
 

--- a/documentation/04_config-options.md
+++ b/documentation/04_config-options.md
@@ -1048,6 +1048,19 @@ speed).
 
 -------
 
+**OUTPUT_LIMITED_TIMESTEP**
+
+By default, output times are mapped to a multiple of MaxSizeTimestep. 
+This means that a high output cadence, i.e. consecutive outputs within 
+half the MaxSizeTimestep value, can lead to the omission of files. When 
+enabled, this maps output times to a finer time grid, determined by the 
+parameter `OutputTimePrecision`. It also limits the size of timesteps near 
+output times. Of course, an alternative solution is to lower the value of
+MaxSizeTimestep. However, this affects all timesteps, regardless of whether
+the high output cadence only occurs during a subset of the simulation.
+
+-------
+
 On the fly FOF groupfinder                                  {#fof}
 ==========================
 

--- a/documentation/05_parameterfile.md
+++ b/documentation/05_parameterfile.md
@@ -667,6 +667,15 @@ ignored.
 
 -------
 
+**OutputTimePrecision**
+
+This determines the size of the time grid used to map the requested output 
+times. Smaller values correspond to output times closer to the requested 
+ones. If `OUTPUT_LIMITED_TIMESTEP` is not enabled, this will default to 
+`MaxSizeTimestep`.
+
+-------
+
 **TimeOfFirstSnapshot**  0.047619048
 
 This variable selects the time for the first snapshot (relevant only

--- a/src/data/allvars.cc
+++ b/src/data/allvars.cc
@@ -199,6 +199,10 @@ void global_data_all_processes::register_parameters(void)
   add_param("A_StaticHQHalo", &A_StaticHQHalo, PARAM_DOUBLE, PARAM_FIXED);
   add_param("Mass_StaticHQHalo", &Mass_StaticHQHalo, PARAM_DOUBLE, PARAM_FIXED);
 #endif
+
+#ifdef OUTPUT_LIMITED_TIMESTEP
+  add_param("OutputTimePrecision", &OutputTimePrecision, PARAM_DOUBLE, PARAM_CHANGEABLE);
+#endif
 }
 
 /*! \brief This function reads a table with a list of desired output times.

--- a/src/data/allvars.h
+++ b/src/data/allvars.h
@@ -166,7 +166,7 @@ struct global_data_all_processes : public parameters
 #endif
 
   int SnapshotFileCount;        /**< number of snapshot that is written next */
-  double TimeBetSnapshot;       /**< simulation time interval between snapshot files */
+  double TimeBetSnapshot;       /**< simulation time interval between snapshot files */ // NOTE: can this be used for limiting timestep size near output?
   double TimeOfFirstSnapshot;   /**< simulation time of first snapshot files */
   double CpuTimeBetRestartFile; /**< cpu-time between regularly generated restart files */
   double TimeLastRestartFile;   /**< cpu-time when last restart-file was written */
@@ -350,6 +350,10 @@ struct global_data_all_processes : public parameters
 #ifdef EXTERNALGRAVITY_STATICHQ
   double A_StaticHQHalo;
   double Mass_StaticHQHalo;
+#endif
+
+#ifdef OUTPUT_LIMITED_TIMESTEP
+  double OutputTimePrecision;
 #endif
 
   void set_cosmo_factors_for_current_time(void);

--- a/src/data/allvars.h
+++ b/src/data/allvars.h
@@ -166,13 +166,17 @@ struct global_data_all_processes : public parameters
 #endif
 
   int SnapshotFileCount;        /**< number of snapshot that is written next */
-  double TimeBetSnapshot;       /**< simulation time interval between snapshot files */ // NOTE: can this be used for limiting timestep size near output?
+  double TimeBetSnapshot;       /**< simulation time interval between snapshot files */
   double TimeOfFirstSnapshot;   /**< simulation time of first snapshot files */
   double CpuTimeBetRestartFile; /**< cpu-time between regularly generated restart files */
   double TimeLastRestartFile;   /**< cpu-time when last restart-file was written */
   double TimeBetStatistics;     /**< simulation time interval between computations of energy statistics */
   double TimeLastStatistics;    /**< simulation time when the energy statistics was computed the last time */
   int NumCurrentTiStep;         /**< counts the number of system steps taken up to this point */
+
+#ifdef OUTPUT_LIMITED_TIMESTEP
+  double TimeToNextOutput; /**< time to next data output */
+#endif
 
   /* Current time of the simulation, global step, and end of simulation */
 

--- a/src/main/run.cc
+++ b/src/main/run.cc
@@ -164,7 +164,7 @@ void sim::run(void)
 #endif
       create_snapshot_if_desired();
 
-/* Calculates how long until we need an outputfile. Used to limit
+/* Calculates how long until we need an output file. Used to limit
    timesteps when close. */ 
 #ifdef OUTPUT_LIMITED_TIMESTEP
       if (All.ComovingIntegrationOn)
@@ -381,7 +381,7 @@ integertime sim::find_next_outputtime(integertime ti_curr)
 
 #ifndef OUTPUT_NON_SYNCHRONIZED_ALLOWED
               /* We will now modify 'ti' to map it to the closest available output time according to either MaxSizeTimestep
-               * or OutputTimePrecision, if the latter if defined. The real output time may hence deviate by half the value 
+               * or OutputTimePrecision, if the latter is defined. The real output time may hence deviate by half the value 
                *  of either of these quantities from the desired output time.
                */
 

--- a/src/main/run.cc
+++ b/src/main/run.cc
@@ -382,7 +382,7 @@ integertime sim::find_next_outputtime(integertime ti_curr)
 #ifndef OUTPUT_NON_SYNCHRONIZED_ALLOWED
               /* We will now modify 'ti' to map it to the closest available output time according to either MaxSizeTimestep
                * or OutputTimePrecision, if the latter is defined. The real output time may hence deviate by half the value 
-               *  of either of these quantities from the desired output time.
+               * of either of these quantities from the desired output time.
                */
 
               /* first, determine maximum output interval, based on All.MaxSizeTimestep or All.OutputTimePrecision */
@@ -457,13 +457,16 @@ integertime sim::find_next_outputtime(integertime ti_curr)
             ti = (integertime)((time - All.TimeBegin) / All.Timebase_interval);
 
 #ifndef OUTPUT_NON_SYNCHRONIZED_ALLOWED
-          /* We will now modify 'ti' to map it to the closest available output time according to the specified MaxSizeTimestep.
-           * The real output time may hence deviate by  +/- 0.5*MaxSizeTimestep from the desired output time.
+          /* We will now modify 'ti' to map it to the closest available output time according to either MaxSizeTimestep
+           * or OutputTimePrecision, if the latter is defined. The real output time may hence deviate by half the value 
+           * of either of these quantities from the desired output time.
            */
 
-          /* first, determine maximum output interval based on All.MaxSizeTimestep */
+#ifdef OUTPUT_LIMITED_TIMESTEP
+          integertime timax = (integertime)(All.OutputTimePrecision / All.Timebase_interval);
+#else
           integertime timax = (integertime)(All.MaxSizeTimestep / All.Timebase_interval);
-
+#endif
           /* make it a power 2 subdivision */
           integertime ti_min = TIMEBASE;
           while(ti_min > timax)

--- a/src/main/run.cc
+++ b/src/main/run.cc
@@ -164,6 +164,15 @@ void sim::run(void)
 #endif
       create_snapshot_if_desired();
 
+/* Calculates how long until we need an outputfile. Used to limit
+   timesteps when close. */ 
+#ifdef OUTPUT_LIMITED_TIMESTEP
+      if (All.ComovingIntegrationOn)
+        All.TimeToNextOutput = log(All.get_absolutetime_from_integertime(All.Ti_nextoutput)) - log(All.Time);
+      else
+        All.TimeToNextOutput = All.get_absolutetime_from_integertime(All.Ti_nextoutput) - All.Time;
+#endif
+
 #ifdef DEBUG_MD5
       Logs.log_debug_md5("AFTER SNAP");
 #endif
@@ -371,12 +380,17 @@ integertime sim::find_next_outputtime(integertime ti_curr)
                 ti = (integertime)((time - All.TimeBegin) / All.Timebase_interval);
 
 #ifndef OUTPUT_NON_SYNCHRONIZED_ALLOWED
-              /* We will now modify 'ti' to map it to the closest available output time according to the specified MaxSizeTimestep.
-               * The real output time may hence deviate by  +/- 0.5*MaxSizeTimestep from the desired output time.
+              /* We will now modify 'ti' to map it to the closest available output time according to either MaxSizeTimestep
+               * or OutputTimePrecision, if the latter if defined. The real output time may hence deviate by half the value 
+               *  of either of these quantities from the desired output time.
                */
 
-              /* first, determine maximum output interval based on All.MaxSizeTimestep */
+              /* first, determine maximum output interval, based on All.MaxSizeTimestep or All.OutputTimePrecision */
+#ifdef OUTPUT_LIMITED_TIMESTEP
+              integertime timax = (integertime)(All.OutputTimePrecision / All.Timebase_interval);
+#else
               integertime timax = (integertime)(All.MaxSizeTimestep / All.Timebase_interval);
+#endif
 
               /* make it a power 2 subdivision */
               integertime ti_min = TIMEBASE;

--- a/src/time_integration/timestep.cc
+++ b/src/time_integration/timestep.cc
@@ -208,6 +208,13 @@ integertime simparticles::get_timestep_grav(int p /*!< particle index */)
   if(dt >= All.MaxSizeTimestep)
     dt = All.MaxSizeTimestep;
 
+  /* Limits the timestep if we are close to an output time. Need to enforce non-zero value as otherwise
+     it will halt the simulation when we coincide in time with an output time. */
+#ifdef OUTPUT_LIMITED_TIMESTEP
+  if(dt >= All.TimeToNextOutput && All.TimeToNextOutput > 0)
+    dt = All.TimeToNextOutput;
+#endif
+
 #if defined(SELFGRAVITY) && defined(PMGRID) && !defined(TREEPM_NOTIMESPLIT)
   if(dt >= All.DtDisplacement)
     dt = All.DtDisplacement;
@@ -338,6 +345,13 @@ integertime simparticles::get_timestep_hydro(int p /*!< particle index */)
 
   if(dt >= All.MaxSizeTimestep)
     dt = All.MaxSizeTimestep;
+
+  /* Limits the timestep if we are close to an output time. Need to enforce non-zero value as otherwise
+     it will halt the simulation when we coincide in time with an output time. */
+#ifdef OUTPUT_LIMITED_TIMESTEP
+  if(dt >= All.TimeToNextOutput && All.TimeToNextOutput > 0)
+    dt = All.TimeToNextOutput;
+#endif
 
 #if defined(PMGRID) && !defined(TREEPM_NOTIMESPLIT)
   if(dt >= All.DtDisplacement)


### PR DESCRIPTION
Adds a new Config flag (OUTPUT_LIMITED_TIMESTEP) and parameter (OutputTimePrecision). These enable the code to save  synchronised, high cadence data outputs whilst taking as large of a timestep as possible if not near output times.

Originally, one or more consecutive outputs would be skipped if they were spaced within a factor of $\Delta \log a \sim 0.5 \times \mathrm{MaxSizeTimestep}$. Thus, MaxSizeTimestep would need to be as small as the smallest output time difference. However, this is counterproductive if good output time resolution is only needed during a subset of the simulation (e.g. late times). Since MaxSizeTimestep affects all the simulation, smaller timesteps than necessary would be used even when no outputs are requested, leading to longer run times.  

These changes were possible in two ways:

- Output times are mapped to an integer timeline whose size is set by OutputTimePrecision (Originally set as MaxSizeTimestep)
- The particle timestep has an additional limiter based on the time to the next output. This ensures all particles are synchronised when they need to be output.